### PR TITLE
fix: Frequency#toString breaks buildKey

### DIFF
--- a/src/main/java/edivad/dimstorage/api/Frequency.java
+++ b/src/main/java/edivad/dimstorage/api/Frequency.java
@@ -72,7 +72,7 @@ public record Frequency(Optional<GameProfile> gameProfile, int channel) implemen
 
   @Override
   public String toString() {
-    return "gameProfile=" + (this.hasOwner() ? this.gameProfile : "public") + ",channel=" + this.channel;
+    return "gameProfile=" + (this.hasOwner() ? this.gameProfile.get().getId() : "public") + ",channel=" + this.channel;
   }
 
   public CompoundTag serializeNBT() {


### PR DESCRIPTION
Previously Frequency::toString would give something nearly random that is not reproducible by player, breaking buildKey's intended purpose.

Results in players getting many unique storages and being unable to access them (without incredible luck) after switching frequencies, toggling publicity, or toggling locking.